### PR TITLE
Add drill holes to Pheonix MPT series

### DIFF
--- a/TerminalBlock_Pheonix_MPT-2.54mm_2pol.kicad_mod
+++ b/TerminalBlock_Pheonix_MPT-2.54mm_2pol.kicad_mod
@@ -21,6 +21,8 @@
   (fp_line (start -1.52908 -3.0988) (end -1.52908 3.0988) (layer F.SilkS) (width 0.15))
   (pad 2 thru_hole oval (at 2.54 0) (size 1.99898 1.99898) (drill 1.09728) (layers *.Cu *.Mask))
   (pad 1 thru_hole rect (at 0 0) (size 1.99898 1.99898) (drill 1.09728) (layers *.Cu *.Mask))
+  (pad "" np_thru_hole circle (at 0 2.54) (size 1.1 1.1) (drill 1.1) (layers *.Cu *.Mask))
+  (pad "" np_thru_hole circle (at 2.54 2.54) (size 1.1 1.1) (drill 1.1) (layers *.Cu *.Mask))
   (model Terminal_Blocks.3dshapes/TerminalBlock_Pheonix_MPT-2.54mm_2pol.wrl
     (at (xyz 0.05 0 0))
     (scale (xyz 1 1 1))

--- a/TerminalBlock_Pheonix_MPT-2.54mm_3pol.kicad_mod
+++ b/TerminalBlock_Pheonix_MPT-2.54mm_3pol.kicad_mod
@@ -23,6 +23,9 @@
   (pad 3 thru_hole oval (at 5.08 0) (size 1.99898 1.99898) (drill 1.09728) (layers *.Cu *.Mask))
   (pad 1 thru_hole rect (at 0 0) (size 1.99898 1.99898) (drill 1.09728) (layers *.Cu *.Mask))
   (pad 2 thru_hole oval (at 2.54 0) (size 1.99898 1.99898) (drill 1.09728) (layers *.Cu *.Mask))
+  (pad "" np_thru_hole circle (at 0 2.54) (size 1.1 1.1) (drill 1.1) (layers *.Cu *.Mask))
+  (pad "" np_thru_hole circle (at 2.54 2.54) (size 1.1 1.1) (drill 1.1) (layers *.Cu *.Mask))
+  (pad "" np_thru_hole circle (at 5.08 2.54) (size 1.1 1.1) (drill 1.1) (layers *.Cu *.Mask))
   (model Terminal_Blocks.3dshapes/TerminalBlock_Pheonix_MPT-2.54mm_3pol.wrl
     (at (xyz 0.1 0 0))
     (scale (xyz 1 1 1))


### PR DESCRIPTION
On any documentation for this series e.g. technical data on purchasing sites, https://www.phoenixcontact.com/online/portal/us?uri=pxc-oc-itemdetail:pid=1725669 (I can't find a general series information page) there tends to be a note that:

> The 2 and 3-pos. versions have an additional locating pin (1.5 mm long) to support the mechanical load."

This only appears to occur for the MPT series. This adds the drill-hole for these models to the footprint.